### PR TITLE
Treat Invalid Links as Errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
 
   complete:
     runs-on: ubuntu-latest
+    needs: build
     name: Build completion task
     steps:
       - run: echo "Build Complete"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: Build Documentation
 on:
-    push:
-        branches:
-            - 'main'
+  push:
+    branches:
+      - 'main'
 
-    workflow_dispatch:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -18,36 +18,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-    build:
-        environment:
-          name: github-pages
-          url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Clone Repository
-              uses: actions/checkout@v4
-              with:
-                submodules: recursive
+  build:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-            - name: Setup .NET SDK
-              uses: actions/setup-dotnet@v4
-              with:
-                dotnet-version: '8.0.x'
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
-            - name: Restore dotnet tools
-              run: dotnet tool restore
+      - name: Restore dotnet tools
+        run: dotnet tool restore
 
-            - name: Run Build
-              run: dotnet docfx docfx.json
+      - name: Run Build
+        run: dotnet docfx docfx.json
 
-            - name: Setup Pages
-              uses: actions/configure-pages@v5
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
-            - name: Upload artifact
-              uses: actions/upload-pages-artifact@v3
-              with:
-                path: '_site'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site'
 
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  complete:
+    runs-on: ubuntu-latest
+    name: Build completion task
+    steps:
+      - run: echo "Build Complete"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build Documentation
+name: Build and Deploy Documentation
 on:
   push:
     branches:
@@ -51,10 +51,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-  complete:
-    runs-on: ubuntu-latest
-    needs: build
-    name: Build completion task
-    steps:
-      - run: echo "Build Complete"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -38,6 +38,7 @@ jobs:
           run: dotnet docfx docfx.json
     complete:
       runs-on: ubuntu-latest
+      needs: test
       name: Build completion task
       steps:
         - run: echo "Tests Complete"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,4 +1,5 @@
-name: Build Documentation
+name: Test Build Documentation
+
 on:
   pull_request:
     branches:
@@ -18,27 +19,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-    test:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Clone Repository
-          uses: actions/checkout@v4
-          with:
-            submodules: recursive
+  test:
+    runs-on: ubuntu-latest
+    concurrency: ci-${{ github.ref }}
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
 
-        - name: Setup .NET SDK
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '8.0.x'
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
-        - name: Restore dotnet tools
-          run: dotnet tool restore
+      - name: Restore dotnet tools
+        run: dotnet tool restore
 
-        - name: Run Build
-          run: dotnet docfx docfx.json
-    complete:
-      runs-on: ubuntu-latest
-      needs: test
-      name: Test completion task
-      steps:
-        - run: echo "Tests Complete"
+      - name: Run Build
+        run: dotnet docfx docfx.json
+
+  complete:
+    runs-on: ubuntu-latest
+    needs: test
+    name: Test completion task
+    steps:
+      - run: echo "Tests Complete"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -39,6 +39,6 @@ jobs:
     complete:
       runs-on: ubuntu-latest
       needs: test
-      name: Build completion task
+      name: Test completion task
       steps:
         - run: echo "Tests Complete"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,43 @@
+name: Build Documentation
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write           
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+    test:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Clone Repository
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
+
+        - name: Setup .NET SDK
+          uses: actions/setup-dotnet@v4
+          with:
+            dotnet-version: '8.0.x'
+
+        - name: Restore dotnet tools
+          run: dotnet tool restore
+
+        - name: Run Build
+          run: dotnet docfx docfx.json
+    complete:
+      runs-on: ubuntu-latest
+      name: Build completion task
+      steps:
+        - run: echo "Tests Complete"

--- a/api/index.md
+++ b/api/index.md
@@ -7,4 +7,4 @@ Welcome to the **MonoGame** reference documentation!
 
 This area provides detailed information on each class and method in the API.
 
-Please view the [documentation](../articles/) for how to get started and step-by-step guidance.
+Please view the [documentation](../articles/index.md) for how to get started and step-by-step guidance.

--- a/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -26,7 +26,8 @@ When installing Visual Studio, the following workloads are required depending on
 ![Visual Studio optional components](images/1_installer_vs_components.png)
 
 > [!WARNING]
-> Targeting Windows
+> **Targeting Windows**
+>
 > If you are targeting the standard Windows DirectX backend, you will also need [the DirectX June 2010 runtime](https://www.microsoft.com/en-us/download/details.aspx?id=8109) for audio and gamepads to work properly.
 
 ### Install MonoGame extension for Visual Studio 2022

--- a/articles/toc.yml
+++ b/articles/toc.yml
@@ -67,4 +67,4 @@
 - name: Help and Support
   href: help_and_support.md
 - name: Contributing to documentation
-  href: contributing
+  href: contributing.md

--- a/docfx.json
+++ b/docfx.json
@@ -21,6 +21,7 @@
   ],
   "rules": {
     "InvalidFileLink": "error",
+    "InvalidBookmark": "error",
     "UidNotFound": "error",
     "ReferencedXrefPropertyNotString": "error"
   },  

--- a/docfx.json
+++ b/docfx.json
@@ -39,7 +39,8 @@
           "foundation/**/*.md",
           "toc.yml",
           "*.md"
-        ]
+        ],
+        "exclude": [ "_site/**", "README.md" ]
       }
     ],
     "resource": [

--- a/docfx.json
+++ b/docfx.json
@@ -19,6 +19,11 @@
       "EnumSortOrder": "alphabetic"
     }
   ],
+  "rules": {
+    "InvalidFileLink": "error",
+    "UidNotFound": "error",
+    "ReferencedXrefPropertyNotString": "error"
+  },  
   "build": {
     "content": [
       {


### PR DESCRIPTION
## Description
This PR updates the `docfx.json` configuration file to add a rule set that will force a build error if there is an invalid link or uid ref detected on build.

> [!WARNING]
> The CI of this PR is going to fail due to invalid UID refs and links.  That means this PR is doing what it's supposed to do. Those issues should be resolved in a separate PR.

## Related Issues
https://github.com/MonoGame/docs.monogame.github.io/issues/11