### PR TITLE
Updates the url for WINE Setup Script

### DIFF
--- a/articles/getting_started/1_setting_up_your_development_environment_unix.md
+++ b/articles/getting_started/1_setting_up_your_development_environment_unix.md
@@ -58,7 +58,7 @@ sudo apt install wine64 p7zip-full curl
 Create wine prefix:
 
 ```sh
-wget -qO- https://raw.githubusercontent.com/MonoGame/MonoGame/master/Tools/MonoGame.Effect.Compiler/mgfxc_wine_setup.sh | bash
+wget -qO- https://monogame.net/downloads/net6_mgfxc_wine_setup.sh | bash
 ```
 
 If you ever need to undo the script, simply delete the `.winemonogame` folder in your home directory.


### PR DESCRIPTION
## Description
The WINE setup scripts were moved to be hosted on the website. This updates the url in the documentation.

Reference:
- https://github.com/MonoGame/monogame.github.io/pull/134