### PR TITLE
Fix effect table by removing hrs and asterisks

### DIFF
--- a/articles/content_pipeline/custom_effects.md
+++ b/articles/content_pipeline/custom_effects.md
@@ -42,6 +42,7 @@ To use a custom effect with MonoGame you must do one of the following:
 * Process your effect file with the [MGFXC tool](../tools/mgfxc.md) and load them yourself at runtime.
 
 ## Effect Writing Tips
+
 These are some tips for writing or converting effects for use with MonoGame.
 
 | The supported shader models when targeting DX are the following:|

--- a/articles/content_pipeline/custom_effects.md
+++ b/articles/content_pipeline/custom_effects.md
@@ -42,28 +42,27 @@ To use a custom effect with MonoGame you must do one of the following:
 * Process your effect file with the [MGFXC tool](../tools/mgfxc.md) and load them yourself at runtime.
 
 ## Effect Writing Tips
-
 These are some tips for writing or converting effects for use with MonoGame.
 
 | The supported shader models when targeting DX are the following:|
 |---|
-|  * `vs_4_0_level_9_1` and `ps_4_0_level_9_1`|
-|  * `vs_4_0_level_9_3` and `ps_4_0_level_9_3`|
-|  * `vs_4_0` and `ps_4_0` (requires `HiDef` `GraphicsProfile` at runtime)|
-|  * `vs_4_1` and `ps_4_1` (requires `HiDef` `GraphicsProfile` at runtime)|
-|  * `vs_5_0` and `ps_5_0` (requires `HiDef` `GraphicsProfile` at runtime)|
----
+|  `vs_4_0_level_9_1` and `ps_4_0_level_9_1`|
+|  `vs_4_0_level_9_3` and `ps_4_0_level_9_3`|
+|  `vs_4_0` and `ps_4_0` (requires `HiDef` `GraphicsProfile` at runtime)|
+|  `vs_4_1` and `ps_4_1` (requires `HiDef` `GraphicsProfile` at runtime)|
+|  `vs_5_0` and `ps_5_0` (requires `HiDef` `GraphicsProfile` at runtime)|
+
 |When targeting GL platforms we automatically translate FX files to GLSL using a library called [MojoShader](http://icculus.org/mojoshader/).  The supported feature levels are the following:|
 |---|
-|  * `vs_2_0` and `ps_2_0`|
-|  * `vs_3_0` and `ps_3_0`|
----
+|  `vs_2_0` and `ps_2_0`|
+|  `vs_3_0` and `ps_3_0`|
+
 |You can use preprocessor checks to add conditional code or compilation depending on defined symbols. MonoGame defines the following symbols when compiling effects:|
 |---|
-|  * `2MGFX`                        |
-|  * `HLSL` and `SM4` for DirectX   |
-|  * `OpenGL` and `GLSL` for OpenGL |
----
+|  `2MGFX`                        |
+|  `HLSL` and `SM4` for DirectX   |
+|  `OpenGL` and `GLSL` for OpenGL |
+
   
 As an example, you can conditionally set shader models depending on the platform with the following code:
 


### PR DESCRIPTION
This is to fix issue #19 

The (---) hr character is not always supported in markdown parsing and seems to be causing the issue here. It shows up good in VS and GitHub md preview, but is not making it into the html. Removing it actually seems to look okay as the generated tables have outlines and a good amount of spacing around them.

The asterisks were not breaking anything, but get printed as just literal asterisks. Not sure if that is intentional so I just removed them because it seems to look better and is easier to copy without them. Let me know if I should not have done that!

Here is a preview image:

![image](https://github.com/MonoGame/docs.monogame.github.io/assets/8315690/eeb3fb1c-500b-457b-905a-b12540eabfb7)
