### PR TITLE
Improved whitespace

### DIFF
--- a/templates/monogame/public/main.css
+++ b/templates/monogame/public/main.css
@@ -181,3 +181,35 @@ box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
   text-decoration: none;
   color: var(--bs-body-color);
 }
+
+
+/*******************************************************************************
+*** Some adjustments to give the content some space.
+*******************************************************************************/
+
+h1 {
+  margin-top: 1.5em;
+}
+h2 {
+  margin-top: 1.25em;
+}
+h3 {
+  margin-top: 1em;
+}
+h4 {
+  margin-top: 0.75em;
+}
+h5 {
+  margin-top: 0.5em;
+}
+
+p img {
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.alert
+{
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}


### PR DESCRIPTION
This improves the whitespace in the doc site:

Before:
![image](https://github.com/user-attachments/assets/27f459cf-b1fc-4207-8f7d-acab16ea1d17)

After:
![image](https://github.com/user-attachments/assets/182f6b9c-e481-4ba4-add2-b4f270a4da06)


Before:
![image](https://github.com/user-attachments/assets/ac34410d-9b5e-4d9a-9f35-875a727d3fbc)

After:
![image](https://github.com/user-attachments/assets/32df359b-b38c-407b-9d18-417dad76ed92)


Fixes https://github.com/MonoGame/monogame.github.io/issues/146.
