### PR TITLE
Adds a warning since the Visual Studio 2022 MonoGame extension is currently broken.

### DIFF
--- a/articles/getting_started/2_choosing_your_ide_visual_studio.md
+++ b/articles/getting_started/2_choosing_your_ide_visual_studio.md
@@ -35,6 +35,16 @@ When installing Visual Studio, the following workloads are required depending on
 
 To create new MonoGame projects from within Visual Studio 2022, you will need to install the **MonoGame Framework C# project templates** extension.  The following steps demonstrate how to install the extension.
 
+> [!WARNING]
+> **Visual Studio Extension Issues**
+> 
+> The extension that is installed by Visual Studio 2022 is currently outdated.
+> Instead of using Visual Studio 2022 to install the templates, run the following command:
+> ```sh
+>    dotnet new install MonoGame.Templates.CSharp
+>  ```
+> After doing this, you should be able to launch Visual Studio 2022 and create a new project with the newly installed templates.
+
 1. Launch Visual Studio 2022
 2. Select **Continue without code**.  This will launch Visual Studio without any project or solution opened.
 


### PR DESCRIPTION
Adds a warning to alert new users that the Visual Studio 2022 MonoGame extension has not been updated.
![image](https://github.com/user-attachments/assets/cbc062ec-5f46-4945-b43e-5018c1804a07)

Based off of personal experience and this discord post from @AristurtleDev 
https://discord.com/channels/355231098122272778/402546044274999299/1293957422112575579
