### PR TITLE
Add search bar

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -64,7 +64,8 @@
       "_hostname": "monogame.net",
       "_openGraphImage": "images/social_embed_image.png",
       "_description": "One framework for creating powerful cross-platform games.",
-      "_appTitle": "MonoGame"
+      "_appTitle": "MonoGame",
+      "_enableSearch": true
     },
     "template": [
       "default",


### PR DESCRIPTION
Addresses issue #91

Turns on DocFX's search bar for the doc site. Here is an example of searching for `DepthStencilState` in my local doc site.

![image](https://github.com/user-attachments/assets/bfd3dd67-be4d-4906-b1fa-90251c47c11a)

DocFX's search bar is powered by lunr.js and therefore is subject to the idiosyncrasies of this search engine as described in the [lunr docs](https://lunrjs.com/guides/searching.html). 

For example, lunr assumes each term in the search query is atomic. So searching for `graph` and `graphic` will yield different results. 

![image](https://github.com/user-attachments/assets/5666237a-0244-4984-920f-aa29f47bdec2)

Additionally, lunr assumes a logical OR when searching with multiple terms. Therefore, searching `aspect ratio` will return the combined results of the two separate search queries for `aspect` and `ratio` but not for the specific phrase `aspect ratio`. This can be partially mitigated by using the search query `+aspect +ratio` but this will only serve to return documents that have both of these words but not necessarily together in the phrase `aspect ratio`

So the search functionality that DocFX provides is not perfect, but I do believe that the additional functionality it has over the ToC filter makes it worth enabling.