### PR TITLE
Update mgfxc docs with the correct code sample

### DIFF
--- a/articles/getting_started/tools/mgfxc.md
+++ b/articles/getting_started/tools/mgfxc.md
@@ -62,7 +62,7 @@ The resulting compiled effect file can be used from your game code like so:
 
 ```csharp
 byte[] bytecode = File.ReadAllBytes("mycompiled.mgfx");
-var effect = new Effect(bytecode);
+var effect = new Effect(graphicsDevice, bytecode);
 ```
 
 This is how the stock effects (BasicEffect, DualTextureEffect, etc) are compiled and loaded.


### PR DESCRIPTION
# Summary

At the end of page https://docs.monogame.net/articles/getting_started/tools/mgfxc.html there is the following code sample:

byte[] bytecode = File.ReadAllBytes("mycompiled.mgfx"); var effect = new Effect(bytecode);

It's is not working has the Effect class has no such constructor. The closest available constructor is Effect(GraphicsDevice graphicsDevice, byte[] effectCode).

## Changes

- Resolves #84

