### PR TITLE
Navbar Adjustments

### DIFF
--- a/templates/monogame/layout/_master.tmpl
+++ b/templates/monogame/layout/_master.tmpl
@@ -78,6 +78,7 @@
     {{/_enableSearch}}
 
       {{>partials/footer}}
+      <script type="text/javascript" src="./public/injectDonateButton.js" /
   </body>
 {{/redirect_url}}
 </html>

--- a/templates/monogame/partials/topnav.tmpl.partial
+++ b/templates/monogame/partials/topnav.tmpl.partial
@@ -18,11 +18,6 @@
                     {{/_enableSearch}}
                 </div>
             </div>
-            <div>
-                <a class="btn mg-donate-button ms-3" type="button" href="https://monogame.net/donate">
-                    <i class="bi bi-heart"></i> Donate
-                </a>
-            </div>
         </div>
     </nav>
 </header>

--- a/templates/monogame/public/injectDonateButton.js
+++ b/templates/monogame/public/injectDonateButton.js
@@ -1,0 +1,25 @@
+/**
+ * Donate button Injector
+ * 
+ * This script dynamically adds a "Donate" button to the navigation.
+ * Since the navbar is dynamically generated **after page load**, it uses a MutationObserver to watch 
+ * for the form.icons element to be added to the DOM, injects the donate button as its first child
+ * the disconnects the observer.
+ */
+
+document.addEventListener('DOMContentLoaded', function() {
+    const observer = new MutationObserver(function(mutations) {
+        const iconsForm = document.querySelector('form.icons');
+        if (iconsForm) {
+            observer.disconnect();
+            const donateDiv = document.createElement('div');
+            donateDiv.innerHTML = '<a class="btn mg-donate-button ms-3" type="button" href="https://monogame.net/donate"><i class="bi bi-heart"></i> Donate</a>';
+            iconsForm.insertAdjacentElement('afterbegin', donateDiv);
+        }
+    });
+
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true
+    });
+});

--- a/templates/monogame/public/main.css
+++ b/templates/monogame/public/main.css
@@ -73,6 +73,17 @@ color: var(--mg-orange-primary)
 }
 
 /*******************************************************************************
+*** Section: Navbar Fixes
+*** The main monogame website uses bootstrap 5.3.2 while docfx is sitll on
+*** bootstrap 3.4.1.  The following are fixes for the top navbar specifically
+*** so that it looks the same as the main website
+*******************************************************************************/
+nav#autocollapse > div.container-xxl {
+  max-width: 1320px;
+}
+
+
+/*******************************************************************************
 *** Section: MonoGame Utility Classes
 *** Utility classes used throughout the site that provide some MonoGame specific
 *** styling.


### PR DESCRIPTION
### Inject Donate Into Navbar
DocFX dynamically generates the navbar on the client side through the docfx.js code, it's not something that is statically rendered when the page is built.  In order for the Donate button to be placed to the left of the theme switch button like on the main monogame side, the Donate button needs to be injected after the page loads and then after the navbar is dynamically generated.

### Fix Navbar Container Width
DocFX uses Bootstrap 3.4.1 while the main monogame website uses Bootstrap 5.3.2.  This adjusts the navbar container only to match the `max-width` value of the current bootstrap version that is used on the main site so that it appears more centered.