### PR TITLE
Update footer year and license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Microsoft Public License (Ms-PL)
-MonoGame - Copyright © 2009-2023 The MonoGame Team
+MonoGame - Copyright © 2009-2025 MonoGame Foundation, Inc
 
 All rights reserved.
 

--- a/docfx.json
+++ b/docfx.json
@@ -60,7 +60,7 @@
       "_appLogoUrl": "https://monogame.net",
       "_appFaviconPath": "/images/favicon.png",
       "_disableBreadcrumb": "true",
-      "_appFooter": "Copyright © 2009-2024 MonoGame Foundation, Inc.",
+      "_appFooter": "Copyright © 2009-2025 MonoGame Foundation, Inc.",
       "_hostname": "monogame.net",
       "_openGraphImage": "images/social_embed_image.png",
       "_description": "One framework for creating powerful cross-platform games.",

--- a/templates/monogame/partials/footer.tmpl.partial
+++ b/templates/monogame/partials/footer.tmpl.partial
@@ -61,7 +61,7 @@
 
         <div class="d-flex flex-column flex-sm-row justify-content-between align-items-center gap-3 py-4 my-4">
             <div>
-                © 2009-2024 MonoGame Foundation, Inc. is a 501(c)(3) non-profit. EIN 93-3803929<br/>Designed with
+                © 2009-2025 MonoGame Foundation, Inc. is a 501(c)(3) non-profit. EIN 93-3803929<br/>Designed with
                 <span class="text-danger">❤</span>
                 by
                 <a href="https://github.com/MonoGame/monogame.github.io/graphs/contributors">MonoGame Community</a>


### PR DESCRIPTION
Small update to increment the footer year and change the copyright text on the license on this repo to match the MonoGame Foundation messaging used elsewhere. 