### PR TITLE
Add Redirect Feature or Error Documentation Links

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -40,6 +40,7 @@
           "foundation/**/*.md",
           "roadmap/**/*.md",
           "roadmap/**/*.yml",
+          "errors/**/*.md",
           "toc.yml",
           "*.md"
         ],

--- a/errors/setupwine/index.md
+++ b/errors/setupwine/index.md
@@ -1,0 +1,5 @@
+---
+redirect: ../../articles/tutorials/building_2d_games/02_getting_started/index.md?tabs=windows#setup-wine-for-effect-compilation-macos-and-linux-only
+---
+
+[url_validation](../../articles/tutorials/building_2d_games/02_getting_started/index.md?tabs=windows#setup-wine-for-effect-compilation-macos-and-linux-only)

--- a/templates/monogame/conceptual.extension.js
+++ b/templates/monogame/conceptual.extension.js
@@ -3,6 +3,10 @@
  */
 exports.preTransform = function (model) {
 
+       // Handle redirect urls that end with .md
+       if(model.redirect) {
+        model.redirect = model.redirect.replace(/\.md/g, '.html');
+    }
     
     //  For layout pages, ignore injecting title and description as header and
     //  first paragraph

--- a/templates/monogame/layout/_master.tmpl
+++ b/templates/monogame/layout/_master.tmpl
@@ -2,11 +2,11 @@
 {{!include(/^public/.*/)}}
 <!DOCTYPE html>
 <html {{#_lang}}lang="{{_lang}}"{{/_lang}}>
-{{#redirect_url}}
+{{#redirect}}
   {{>partials/redirect}}
-{{/redirect_url}}
+{{/redirect}}
 
-{{^redirect_url}}
+{{^redirect}}
   <head>
     {{>partials/head}}
   </head>
@@ -81,5 +81,5 @@
       <script type="text/javascript" src="/public/injectDonateButton.js"></script>
       <script type="text/javascript" src="/public/questionAnswer.js"></script>
   </body>
-{{/redirect_url}}
+{{/redirect}}
 </html>

--- a/templates/monogame/partials/redirect.tmpl.partial
+++ b/templates/monogame/partials/redirect.tmpl.partial
@@ -1,8 +1,8 @@
 <meta charset="utf-8"/>
 <title>Redirecting&hellip;</title>
 <link rel="canonical" href="{{ redirect.to | url }}"/>
-<script>location = '{{redirect_url}}';</script>
-<meta http-equiv="refresh" content="0; url={{redirect_url}}"/>
+<script>location = '{{redirect}}';</script>
+<meta http-equiv="refresh" content="0; url={{redirect}}"/>
 <meta name="robots" content="noindex"/>
 <h1>Redirecting&hellip;</h1>
-<a href="{{redirect_url}}">Click here if you are not redirected.</a>
+<a href="{{redirect}}">Click here if you are not redirected.</a>


### PR DESCRIPTION
## Summary

This PR implements a redirect system for MonoGame error documentation links.  The system allows us to create stable, short URLs that can be updated without breaking external references, similar to URL shorteners.

**How it works**:

- Create a redirect page in the `/errors/` directory such as `/errors/setupwine/index.md`
- The page generates a clean URL: `https://docs.monogame.net/errors/setupwine`
- When accessed, it automatically redirects to the target documentation.
- If the target changes only the redirect value needs to be updated.

**Example Usage**

```md
---
redirect: ./path/to/target/index.md
---

[redirect](./path/to/target.md]
```

> [!NOTE]
> Due to DocFX's document processing limitations, the redirect URL must appear both in the front matter and as a link in the document body. By including it in the body, this ensures that link validation occurs, while maintaining the redirect functionality.

### Notes

**DocFX Processing Constraints**: DocFX cannot validate YAML frontmatter values using its standard link validation.  To work around this, we include the redirect URL twice:

1. In the `redirect` frontmatter  for the redirect functionality.
2. As a markdown link in the document body for DocFX validation.

### Changes Made

- `docfx.json`: Added `/errors/**/*.md` to content build process
- `master.tmpl`: Change from `redirect_url` to `redirect` property
    - **Reason**: `redirect_url` is a DocFX reserved property that bypasses normal processing and skips `conceptual.extensions.js`, which we need for proper `.md` to `.html` link transformations
- `conceptual.extensions.js`: Added transformation logic for `model.redirect`
    - Converts `.md` extensions to `.html` in the redirect URLs
    - enables use of standard DocFX relative links in both frontmatter and document body
    - Maintains link validation compatibility