### PR TITLE
Create mgfx0001.md

### DIFF
--- a/errors/mgfx0001.md
+++ b/errors/mgfx0001.md
@@ -1,0 +1,25 @@
+---
+title: MonoGame error MGFX0001
+description: MGFX0001 error code
+ms.date: 04/11/2025
+---
+# MonoGame error MGFX0001
+
+## Example messages
+
+```
+Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://docs.monogame.net/errors/mgfx0001?tab=macos for more details.
+```
+
+```
+Error: MGFXC0001: MGFXC effect compiler requires a valid Wine installation to be able to compile shaders. Please visit https://docs.monogame.net/errors/mgfx0001?tab=linux for more details.
+```
+
+## Issue
+
+This error indicates that `Wine` is not installed on the development machine. `Wine` is currently required in order to compile `Effects` on both Linux and MacOS.
+
+## Solution
+
+You need to make sure you have installed `Wine` on your machine. 
+Please look at the following [link](https://docs.monogame.net/articles/tutorials/building_2d_games/02_getting_started/?tabs=macos#setup-wine-for-effect-compilation-macos-and-linux-only) for detailed instructions on how to install `Wine` and configure it for use with MonoGame.


### PR DESCRIPTION
Add an Error page for the first coded MonoGame error. MGFX0001. 

The error codes should be prefixed with the `TOOL`  or assembly which is being used. This will allow us to identify error areas easily.

e.g 

mgfx : MGFX
mgcb: MGCB
MonoGame : MG
Content Pipeline: MGCP

I chose a 4 digit code as that should give us enough room to add as many errors (or warnings) as we need.

In this case we want a page with details on WHAT the error is and then a `Solution` section on how to fix it. 

That said we can also use redirects if need be.

