### PR TITLE
Add information on maui requirements for mobile debugging

### DIFF
--- a/articles/getting_started/1_setting_up_your_os_for_development_macos.md
+++ b/articles/getting_started/1_setting_up_your_os_for_development_macos.md
@@ -17,6 +17,9 @@ To develop with MonoGame in C#, you will need to install the .NET SDK. As of Mon
 
 If you intend to also work with platforms such as `Android` or `iOS`, you will need to install the additional .NET workload templates for those platforms which include additional features and simulators to support those platforms.  Just run the following commands from the terminal for the platforms below you wish to install.
 
+> [!IMPORTANT]
+> For mobile development with iOS and Android, you must also install the MAUI workload even though MonoGame does not use MAUI. The MAUI workload contains the debugging tools required to run and debug mobile .NET applications. Without it, you will not be able to properly debug your MonoGame mobile projects.
+
 ### [Android](#tab/android)
 
 ```cli
@@ -27,6 +30,17 @@ If you intend to also work with platforms such as `Android` or `iOS`, you will n
 
 ```cli
     dotnet workload install ios
+```
+
+### [Maui](#tab/maui)
+```cli
+    dotnet workload install maui
+```
+
+### [Android, iOS, and Maui](#tab/all)
+
+```cli
+    dotnet workload install android ios maui
 ```
 
 ---

--- a/articles/getting_started/1_setting_up_your_os_for_development_ubuntu.md
+++ b/articles/getting_started/1_setting_up_your_os_for_development_ubuntu.md
@@ -21,6 +21,9 @@ To develop with MonoGame in C#, you will need to install the .NET SDK. As of Mon
 
 If you intend to also work with platforms such as `Android` or `iOS`, you will need to install the additional .NET workload templates for those platforms which include additional features and simulators to support those platforms.  Just run the following commands from the terminal for the platforms below you wish to install.
 
+> [!IMPORTANT]
+> For mobile development with iOS and Android, you must also install the MAUI workload even though MonoGame does not use MAUI. The MAUI workload contains the debugging tools required to run and debug mobile .NET applications. Without it, you will not be able to properly debug your MonoGame mobile projects.
+
 ### [Android](#tab/android)
 
 ```cli
@@ -31,6 +34,17 @@ If you intend to also work with platforms such as `Android` or `iOS`, you will n
 
 ```cli
     dotnet workload install ios
+```
+
+### [Maui](#tab/maui)
+```cli
+    dotnet workload install maui
+```
+
+### [Android, iOS, and Maui](#tab/all)
+
+```cli
+    dotnet workload install android ios maui
 ```
 
 ---

--- a/articles/getting_started/1_setting_up_your_os_for_development_windows.md
+++ b/articles/getting_started/1_setting_up_your_os_for_development_windows.md
@@ -26,6 +26,9 @@ You can follow the instructions below based on your operating system to install 
 
 If you intend to also work with platforms such as `Android` or `iOS`, you will need to install the additional .NET workload templates for those platforms which include additional features and simulators to support those platforms.  Just run the command-line command for the platforms below you wish to install.
 
+> [!IMPORTANT]
+> For mobile development with iOS and Android, you must also install the MAUI workload even though MonoGame does not use MAUI. The MAUI workload contains the debugging tools required to run and debug mobile .NET applications. Without it, you will not be able to properly debug your MonoGame mobile projects.
+
 ### [Android](#tab/android)
 
 ```cli
@@ -36,6 +39,17 @@ If you intend to also work with platforms such as `Android` or `iOS`, you will n
 
 ```cli
     dotnet workload install ios
+```
+
+### [Maui](#tab/maui)
+```cli
+    dotnet workload install maui
+```
+
+### [Android, iOS, and Maui](#tab/all)
+
+```cli
+    dotnet workload install android ios maui
 ```
 
 ---

--- a/articles/getting_started/2_choosing_your_ide_vscode.md
+++ b/articles/getting_started/2_choosing_your_ide_vscode.md
@@ -81,6 +81,20 @@ You can find this extension by following the steps above and searching for "Mono
 > [!NOTE]
 > While not built by the MonoGame team, we regularly use this extension ourselves and fully support it.
 
+## (Optional) Install the ".NET MAUI" extension to help with mobile development
+
+This extension is provided by Microsoft and is built on top of the C# and C# Dev Kit extensions. They will be installed as dependencies if they were not already installed. While primarily designed for MAUI development, it provides essential mobile debugging capabilities that MonoGame mobile projects can utilize.
+
+The .NET MAUI extension adds features for building mobile apps, including:
+
+- F5 debugging support - Debug your MonoGame mobile apps on emulators, simulators, and physical devices
+- Easy target switching - Change debug/deploy targets between different mobile platforms
+- Enhanced C# Dev Kit integration - Leverages Solution Explorer, Test Explorer, and advanced language features
+
+> [!NOTE]
+> This extension is recommended if you wish to do iOS or Android development. It is required for debugging support when working on mobile games. 
+
+
 ## Creating a new MonoGame project
 
 1. Open up an empty folder in Visual Studio Code


### PR DESCRIPTION
This is to address issue #111  and also addresses half of #90 

Update the OS specific docs to include install instructions for the maui workload (as well as a tab to install android, ios, and maui altogether).

Updated the VS code doc to explain the benefits of installing the .NET MAUI extension to make debugging mobile games possible.

I do not have any better suggestions for replacing the Xamarin docs for the second part of issue #90 though. So hopefully resolving half the issue is good enough for now ;)