### PR TITLE
Fix formatting of Tip Admonition

### DIFF
--- a/articles/tutorials/building_2d_games/12_collision_detection/index.md
+++ b/articles/tutorials/building_2d_games/12_collision_detection/index.md
@@ -192,7 +192,8 @@ For example, if we had a ball moving around the screen and wanted it to bounce o
 
 [!code-csharp[](./snippets/bounce_example.cs)]
 
-> [!TIP] > [**Vector2.UnitX**](xref:Microsoft.Xna.Framework.Vector2.UnitX) is $(1, 0)$ and [**Vector2.UnitY**](xref:Microsoft.Xna.Framework.Vector2.UnitY) is $(0, 1)$. We use these to get the screen edge normal since the edges of the screen are not at an angle. For more complex surfaces, you would need to calculate the appropriate normal vector based on the surface angle.
+> [!TIP]
+> [**Vector2.UnitX**](xref:Microsoft.Xna.Framework.Vector2.UnitX) is $(1, 0)$ and [**Vector2.UnitY**](xref:Microsoft.Xna.Framework.Vector2.UnitY) is $(0, 1)$. We use these to get the screen edge normal since the edges of the screen are not at an angle. For more complex surfaces, you would need to calculate the appropriate normal vector based on the surface angle.
 
 ### Optimizing Collision Performance
 


### PR DESCRIPTION
The Tip admonition was incorrectly formatted from a recent PR.  This moves corrects it to remove the warning: 

```
warning invalid-note-section: Text in the first line of Note/Section/Video is not valid. Will be rendered to <blockquote>
```