### PR TITLE
For Issue #158 Spelling Mistake In Building 2D Games Tutorial Chapter 5 - ContentManager Methods

### DIFF
--- a/articles/tutorials/building_2d_games/05_content_pipeline/index.md
+++ b/articles/tutorials/building_2d_games/05_content_pipeline/index.md
@@ -161,7 +161,7 @@ To load assets in your game code, MonoGame provides the [**ContentManager**](xre
 
 ### ContentManager Methods
 
-They key methods for asset loading are:
+The key methods for asset loading are:
 
 | Method                                                                                                    | Returns | Description                                                                  |
 | --------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixed a spelling mistake in Chapter 5 of the Building 2D games tutorial. 