### PR TITLE
Remove Confusing "Objects" Terminology from Gum Forms and Visuals Section

### DIFF
--- a/articles/tutorials/building_2d_games/20_implementing_ui_with_gum/index.md
+++ b/articles/tutorials/building_2d_games/20_implementing_ui_with_gum/index.md
@@ -161,11 +161,13 @@ The following docking modes are supported by Gum:
 
 ### Forms and Visuals
 
-Gum provides two types of objects: **Forms** and **Visuals**.
+Two concepts are important when working with Gum: **Forms** and **Visuals**.
 
-* Forms controls are typical interactive UI elements such as buttons, sliders, and text boxes that handle user interaction through mouse, gamepad, and keyboard inputs.  These controls come with built-in functionality; a button responds visually when focused, while a slider changes its value when clicked on its *track*.  By using these standardized components, you can maintain consistency throughout your UI implementation.
+* **Forms** controls are typical interactive UI elements such as buttons, sliders, and text boxes that handle user interaction through mouse, gamepad, and keyboard inputs.  These controls come with built-in functionality; a button responds visually when focused, while a slider changes its value when clicked on its *track*.  By using these standardized components, you can maintain consistency throughout your UI implementation.
 
-* Forms controls provide customization through their `Visual` property, which serves as a gateway to modifying their appearance and layout. With this property, you can move, resize, restyle, and even completely replace visuals through code.  As we will see when building our UI in the next chapter, this separation between functionality and presentation allows us to create consistent behaviors while adapting the visual style to match our game's aesthetic.
+* **Visuals** are the graphical display elements that render the actual appearance of UI components. In Gum, Visual elements have the *Runtime suffix (like TextRuntime, ColoredRectangleRuntime, and NineSliceRuntime) and are used to render graphics. They handle the visual representation but have no built-in interaction behavior on their own.
+
+Forms controls provide customization through their `Visual` property, which serves as a gateway to modifying their appearance and layout. With this property, you can move, resize, restyle, and even completely replace visuals through code.  As we will see when building our UI in the next chapter, this separation between functionality and presentation allows us to create consistent behaviors while adapting the visual style to match our game's aesthetic.
 
 For now, we will examine some of the Forms control types we will use in this chapter.
 


### PR DESCRIPTION
## Description

This pull request addresses community feedback regarding confusing terminology in Chapter 20's explanation of Gum's core concepts.

Resolves: [Issue #143](https://github.com/MonoGame/docs.monogame.github.io/issues/143)

## Changes Made

Updated the "Forms and Visuals" section in "Chapter 20: Implementing UI with Gum" to eliminate terminology confusion by:

- **Replaced "objects" terminology**: Changed from "Gum provides two types of objects" to "Two concepts are important when working with Gum" to avoid OOP confusion
- **Enhanced Visual explanation**: Added clarification about the *Runtime suffix naming convention and specific examples of Visual elements
- **Restructured content flow**: Moved the explanation of Forms controls' `Visual` property relationship outside bullet points for clearer logical progression