### PR TITLE
Fix ExitOnEscape behavior inconsistency in input management tutorial

### DIFF
--- a/articles/tutorials/building_2d_games/11_input_management/index.md
+++ b/articles/tutorials/building_2d_games/11_input_management/index.md
@@ -366,15 +366,16 @@ Now that we have our input management system complete, we will update our game t
 
 The `Core` class serves as our base game class, so we will update it to add and expose the `InputManager` globally.  Open the *Core.cs* file in the *MonoGameLibrary* project and update it to the following:
 
-[!code-csharp[](./snippets/core.cs?highlight=5-6,39-47,103-104,107-118)]
+[!code-csharp[](./snippets/core.cs?highlight=5-6,39-47,91-92,106–107,110–121)]
 
 The key changes to the `Core` class are:
 
 1. Added the `using MonoGameLibrary.Input;` directive to access the `InputManager` class.
 2. Added a static `Input` property to provide global access to the input manager.
 3. Added a static `ExitOnEscape` property to set whether the game should exit when the Escape key on the keyboard is pressed.
-4. In `Initialize` the input manager is created.
-5. Added an override for the `Update` method where:
+4. In the `Core` constructor, `ExitOnEscape` is set to true by default to mirror how the default MonoGame `Game1` class template has this functionality by default.
+5. In `Initialize` the input manager is created.
+6. Added an override for the `Update` method where:
    1. The input manager is updated
    2. A check is made to see if `ExitOnEscape` is true and if the Escape keyboard key is pressed.
 
@@ -382,7 +383,7 @@ The key changes to the `Core` class are:
 
 Now we can update our `Game1` class to use the new input management system through the `Core` class.  Open `Game1.cs` in the game project and update it to the following:
 
-[!code-csharp[](./snippets/game1.cs?highlight=1,7,75,81,87,93,99,107,112,115,119,125,127-128,133,139,145,151)]
+[!code-csharp[](./snippets/game1.cs?highlight=1,7,73,79,85,91,97,105,110,113,117,123,125-126,131,137,143,149)]
 
 The key changes to the `Game1` class are:
 

--- a/articles/tutorials/building_2d_games/11_input_management/snippets/core.cs
+++ b/articles/tutorials/building_2d_games/11_input_management/snippets/core.cs
@@ -87,6 +87,9 @@ public class Core : Game
 
         // Mouse is visible by default.
         IsMouseVisible = true;
+
+        // Exit on escape is true by default
+        ExitOnEscape = true;
     }
 
     protected override void Initialize()

--- a/articles/tutorials/building_2d_games/11_input_management/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/11_input_management/snippets/game1.cs
@@ -50,9 +50,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/12_collision_detection/index.md
+++ b/articles/tutorials/building_2d_games/12_collision_detection/index.md
@@ -311,7 +311,7 @@ If you run the game right now and move the slime around, you will notice a few i
 
 We can now implement these features using collision detection and response in our game. In the *DungeonSlime* project (your main game project), open the `Game1.cs` file and make the following changes to the `Game1` class:
 
-[!code-csharp[](./snippets/game1.cs?highlight=1,5,25-29,40-45,79-179,184-196,296-297)]
+[!code-csharp[](./snippets/game1.cs?highlight=1,5,25-29,40-45,76–176,181–193,293–294)]
 
 The key changes made here are:
 

--- a/articles/tutorials/building_2d_games/12_collision_detection/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/12_collision_detection/snippets/game1.cs
@@ -61,9 +61,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/13_working_with_tilemaps/index.md
+++ b/articles/tutorials/building_2d_games/13_working_with_tilemaps/index.md
@@ -186,7 +186,7 @@ This tilemap configuration creates a simple dungeon layout with walls around the
 
 With all of the assets now in place and configured, we can update the `Game1` class to load the tilemap and draw it. We will also need to update the collision logic so that the boundary is no longer the edge of the screen, but instead the edges of the wall tiles of the tilemap. Open `Game1.cs` and make the following updates:
 
-[!code-csharp[](./snippets/game1.cs?highlight=31-35,46-61,80-82,112,114,116,128,121,123,125,127,145,148,150,153,156,159,161,164,179-181,303-304)]
+[!code-csharp[](./snippets/game1.cs?highlight=31-35,46-61,80-82,109,111,113,125,118,120,122,124,142,145,147,150,153,156,158,161,176–178,300–301)]
 
 The key changes to the `Game1` class include:
 

--- a/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/game1.cs
@@ -84,9 +84,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/14_soundeffects_and_music/index.md
+++ b/articles/tutorials/building_2d_games/14_soundeffects_and_music/index.md
@@ -175,7 +175,7 @@ Add these files to your content project using the MGCB Editor:
 
 Next, open the `Game1.cs` file and update it to the following:
 
-[!code-csharp[](./snippets/game1.cs?highlight=3,6,39-43,92-111,203-204,222-223)]
+[!code-csharp[](./snippets/game1.cs?highlight=3,6,39-43,92-111,200-201,219-220)]
 
 The key changes here are:
 

--- a/articles/tutorials/building_2d_games/14_soundeffects_and_music/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/14_soundeffects_and_music/snippets/game1.cs
@@ -113,9 +113,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/15_audio_controller/index.md
+++ b/articles/tutorials/building_2d_games/15_audio_controller/index.md
@@ -117,7 +117,7 @@ Now that we have the audio controller class complete, we can update the game to 
 
 The `Core` class serves as our base game class, so we will update it first to add and expose the `AudioController` globally. Open the `Core.cs` file in the *MonoGameLibrary* project and update it to the following:
 
-[!code-csharp[](./snippets/core.cs?highlight=6,50-53,112-113,116-122,129-130)]
+[!code-csharp[](./snippets/core.cs?highlight=6,50-53,115–116,119–125,132–133)]
 
 The key changes made here are:
 
@@ -131,7 +131,7 @@ The key changes made here are:
 
 Next, update the `Game1` class to use the audio controller for audio playback. Open `Game1.cs` and make the following updates:
 
-[!code-csharp[](./snippets/game1.cs?highlight=45-46,77-78,104-105,197-198,216-217,270-288)]
+[!code-csharp[](./snippets/game1.cs?highlight=45-46,77-78,104-105,194–195,213–214,267–285)]
 
 > [!NOTE]
 > Note there were a lot of replacements in the `LoadContent` method, switching from loading and initializing the background Song and replacing it with a call to the new `AudioController` to do all the work managing the Song reference. Much cleaner.

--- a/articles/tutorials/building_2d_games/15_audio_controller/snippets/core.cs
+++ b/articles/tutorials/building_2d_games/15_audio_controller/snippets/core.cs
@@ -93,6 +93,9 @@ public class Core : Game
 
         // Mouse is visible by default.
         IsMouseVisible = true;
+
+        // Exit on escape is true by default
+        ExitOnEscape = true;        
     }
 
     protected override void Initialize()

--- a/articles/tutorials/building_2d_games/15_audio_controller/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/15_audio_controller/snippets/game1.cs
@@ -107,9 +107,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/16_working_with_spritefonts/index.md
+++ b/articles/tutorials/building_2d_games/16_working_with_spritefonts/index.md
@@ -217,7 +217,7 @@ The key changes here are:
 
 Finally, open the `Game1.cs` file and make the following changes:
 
-[!code-csharp[](./snippets/game1.cs?highlight=48-58,93-99,129-130,244-245,389-400)]
+[!code-csharp[](./snippets/game1.cs?highlight=48-58,93-99,129-130,240-241,385-396)]
 
 The key changes made are:
 

--- a/articles/tutorials/building_2d_games/16_working_with_spritefonts/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/16_working_with_spritefonts/snippets/game1.cs
@@ -131,9 +131,6 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
-        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed || Keyboard.GetState().IsKeyDown(Keys.Escape))
-            Exit();
-
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 

--- a/articles/tutorials/building_2d_games/17_scenes/index.md
+++ b/articles/tutorials/building_2d_games/17_scenes/index.md
@@ -93,7 +93,7 @@ With the Base scene implementation complete, we can now use it to create actual 
 
 With the base `Scene` class defined, the `Core` class needs to be updated to handle management of the scenes, including update, drawing, and changing scenes.  Open the `Core.cs` file in the *MonoGameLibrary* project and make the following changes:
 
-[!code-csharp[](./snippets/core.cs?highlight=8,21-25,144-155,160-169,171-179,181-205)]
+[!code-csharp[](./snippets/core.cs?highlight=8,21-25,147–158,163–172,174–182,184–208)]
 
 The key changes here are:
 

--- a/articles/tutorials/building_2d_games/17_scenes/snippets/core.cs
+++ b/articles/tutorials/building_2d_games/17_scenes/snippets/core.cs
@@ -100,6 +100,9 @@ public class Core : Game
 
         // Mouse is visible by default.
         IsMouseVisible = true;
+
+        // Exit on escape is true by default
+        ExitOnEscape = true;        
     }
 
     protected override void Initialize()


### PR DESCRIPTION
## Description

This pull request addresses community feedback regarding missing ExitOnEscape functionality after following the input management tutorial, where removing the old input handling code inadvertently disabled the escape key exit behavior.

Resolves: [Issue #142](https://github.com/MonoGame/docs.monogame.github.io/issues/142)

## Changes Made

Updated the input management tutorial to maintain consistent ExitOnEscape behavior by:

- **Added ExitOnEscape initialization in Core constructor**: Set ExitOnEscape = true; in the Core.cs constructor to mimic the default MonoGame template behavior
- **Removed outdated input handling code**: Eliminated the legacy GamePad.GetState() and Keyboard.GetState().IsKeyDown(Keys.Escape) checks from all Game1.cs snippet files throughout the tutorial