### PR TITLE
Update tutorial for drawing masked sprite backgrounds

### DIFF
--- a/articles/getting_to_know/howto/graphics/HowTo_Draw_A_Sprite.md
+++ b/articles/getting_to_know/howto/graphics/HowTo_Draw_A_Sprite.md
@@ -21,7 +21,7 @@ The following texture will be used to render to the screen.
 Save it to your content project and name it "**Character**" (this name will used to reference it in the project).
 
 > [!NOTE]
-> The tutorial assumes you have already [created a new MonoGame project](https://docs.monogame.net/articles/getting_started/index.html#2-creating-a-new-project) using one of the standard templates.
+> The tutorial assumes you have already [created a new MonoGame project](../../../getting_started/index.md#setting-up-and-creating-your-first-monogame-project) using one of the standard templates.
 
 ## To draw a sprite on screen
 
@@ -54,7 +54,7 @@ Save it to your content project and name it "**Character**" (this name will used
 5. Call [SpriteBatch.Draw](xref:Microsoft.Xna.Framework.Graphics.SpriteBatch#Microsoft_Xna_Framework_Graphics_SpriteBatch_Draw_Microsoft_Xna_Framework_Graphics_Texture2D_Microsoft_Xna_Framework_Vector2_Microsoft_Xna_Framework_Color_) on your [SpriteBatch](xref:Microsoft.Xna.Framework.Graphics.SpriteBatch) object, passing the texture to draw, the screen position, and the color to apply.
 
     > [!TIP]
-    > [Color.White](xref:Microsoft.Xna.Framework.Color) is used to draw the texture without any color effects. For a deeper explanation of how sprite tinting works, check out the [How to Tint a Sprite](https://docs.monogame.net/articles/getting_to_know/howto/graphics/HowTo_Tint_Sprite.html) guide.
+    > [Color.White](xref:Microsoft.Xna.Framework.Color) is used to draw the texture without any color effects. For a deeper explanation of how sprite tinting works, check out the [How to Tint a Sprite](HowTo_Tint_Sprite.md) guide.
 
 6. When all the sprites have been drawn, call [SpriteBatch.End](xref:Microsoft.Xna.Framework.Graphics.SpriteBatch#Microsoft_Xna_Framework_Graphics_SpriteBatch_End) on your [SpriteBatch](xref:Microsoft.Xna.Framework.Graphics.SpriteBatch) object.
 

--- a/articles/getting_to_know/howto/graphics/HowTo_Draw_Sprite_Background.md
+++ b/articles/getting_to_know/howto/graphics/HowTo_Draw_Sprite_Background.md
@@ -22,7 +22,7 @@ The example assumes the texture you are loading contains multiple images, one fo
 Save the textures to your content project and name it "**AnimatedCharacter**" (this name will used to reference it in the project).
 
 > [!NOTE]
-> The tutorial assumes you have already viewed the [How to draw a Sprite](https://docs.monogame.net/articles/getting_to_know/howto/graphics/HowTo_Draw_A_Sprite.html) topic.
+> The tutorial assumes you have already viewed the [How to draw a Sprite](HowTo_Draw_A_Sprite.md) topic.
 
 > [!IMPORTANT]
 > The foreground sprite in this example must include masking information, e.g. a PNG or DDS file that supports transparency / an alpha channel.


### PR DESCRIPTION
This pull request makes minor improvements to the sprite drawing code examples in the `HowTo_Draw_Sprite_Background.md` documentation. The changes clarify how to use the `SpriteBatch.Draw` method by specifying the position and color parameters, to fix the error `CS1501: No overload for the method Draw takes 1 arguments `.

- **Documentation improvements:**
  * Updated the usage of `_spriteBatch.Draw` in code examples to include explicit `Vector2.Zero` for position and `Color.White` for color. [[1]](diffhunk://#diff-d51ccde04f95e10902855d9fbaeb7f3ab43b84286f7558d41a8a6e73ee257773L73-R73) [[2]](diffhunk://#diff-d51ccde04f95e10902855d9fbaeb7f3ab43b84286f7558d41a8a6e73ee257773L91-R91)