### PR TITLE
Fix typo in tilemap.cs documentation

### DIFF
--- a/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/tilemap.cs
+++ b/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/tilemap.cs
@@ -104,7 +104,7 @@ public class Tilemap
     }
 
     /// <summary>
-    /// Gets the texture region of the tile frm this tilemap at the specified
+    /// Gets the texture region of the tile from this tilemap at the specified
     /// column and row.
     /// </summary>
     /// <param name="column">The column of the tile in this tilemap.</param>


### PR DESCRIPTION
A very small typo. "frm" -> "from"