### PR TITLE
Fix typo in Chapter 8: game1.cs

### DIFF
--- a/articles/tutorials/building_2d_games/08_the_sprite_class/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/08_the_sprite_class/snippets/game1.cs
@@ -59,7 +59,7 @@ public class Game1 : Core
         SpriteBatch.Begin(samplerState: SamplerState.PointClamp);
 
         // Draw the slime sprite.
-        _slime.Draw(SpriteBatch, Vector2.One);
+        _slime.Draw(SpriteBatch, Vector2.Zero);
 
         // Draw the bat sprite 10px to the right of the slime.
         _bat.Draw(SpriteBatch, new Vector2(_slime.Width + 10, 0));


### PR DESCRIPTION
I found this typo in Chapter 8 of the Getting Started guide:

```C#
// Draw the slime sprite.
_slime.Draw(SpriteBatch, Vector2.One);
```

I believe the scale from a previous example was mistakenly copied to be the position in this example.