### PR TITLE
Use current dir to add MonoGameLibrary reference

### DIFF
--- a/articles/tutorials/building_2d_games/04_creating_a_class_library/index.md
+++ b/articles/tutorials/building_2d_games/04_creating_a_class_library/index.md
@@ -111,7 +111,7 @@ To add the game library project as a reference to the game project in Visual Stu
 To add the game library project as a reference to the game project with the dotnet CLI:
 
 1. Open a new Command Prompt or Terminal window in the same folder as the *DungeonSlime.csproj* C# project file.
-2. Enter the command `dotnet add ./DungeonSlime.csproj reference ../MonoGameLibrary/MonoGameLibrary.csproj`.  This will add the *MonoGameLibrary* reference to the *DungeonSlime* game project.
+2. Enter the command `dotnet add ./DungeonSlime.csproj reference ./MonoGameLibrary/MonoGameLibrary.csproj`.  This will add the *MonoGameLibrary* reference to the *DungeonSlime* game project.
 
 ---
 


### PR DESCRIPTION
The tutorial assumes you're in the `DungeonSlime` directory, with `MonoGameLibrary` as a subdir. Going to the parent dir doesn't make sense and will cause the `dotnet add [...]` command to fail.