### PR TITLE
Fix typo in MonoGame Content Editor description

### DIFF
--- a/articles/getting_started/2_choosing_your_ide_vscode.md
+++ b/articles/getting_started/2_choosing_your_ide_vscode.md
@@ -156,11 +156,11 @@ The .NET MAUI extension adds features for building mobile apps, including:
 
 The MonoGame Content Editor (MGCB) is a tool delivered through NuGet for your project using the tools configuration held in your `dotnet-tools.json` file (located in the `.config` folder of your project).
 
-Once you have created your project you should run the following terminal/command-line command to ensure the tool (and the pipeline) is setup and read for your project:
+Once you have created your project you should run the following terminal/command-line command to ensure the tool (and the pipeline) is setup and ready for your project:
 
 ```dotnetcli
     dotnet tool restore
 ```
 
 > [!NOTE]
-> If you ever change the version of the tools or want to upgrade them by editing the `dotnet-tools.json` configuration, you MUST run this command again to update te tools.
+> If you ever change the version of the tools or want to upgrade them by editing the `dotnet-tools.json` configuration, you MUST run this command again to update the tools.


### PR DESCRIPTION
Corrected a typo in the description of the MonoGame Content Editor.