### PR TITLE
Fix carousel overlap issue

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ description: MonoGame Documentation Hub
     <div id="learnCarousel" class="carousel slide mb-6" data-bs-ride="carousel">
         <div class="carousel-indicators">
             <button type="button" data-bs-target="#learnCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="2D Tutorial Slide"></button>
-            <button type="button" data-bs-target="#learnCarousel" data-bs-slide-to="1" class="active" aria-current="true" aria-label="2D Advanced Shaders Tutorial Slide"></button>
+            <button type="button" data-bs-target="#learnCarousel" data-bs-slide-to="1" aria-label="2D Advanced Shaders Tutorial Slide"></button>
             <!-- <button type="button" data-bs-target="#learnCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button> -->
             <!-- <button type="button" data-bs-target="#learnCarousel" data-bs-slide-to="2" aria-label="Slide 3"></button> -->
         </div>
@@ -32,7 +32,7 @@ description: MonoGame Documentation Hub
                     </div>
                 </div>
             </div>
-            <div class="carousel-item active">
+            <div class="carousel-item">
                 <a href="/articles/tutorials/advanced/2d_shaders/index.html"><video autoplay loop muted style="max-width: 100%; height: auto;" aria-label="Advanced 2D shader tutorial"><source src="/images/learn/2d-shader-banner.webm" type="video/webm"></video></a>
                 <div class="container">
                     <div class="carousel-caption text-start">


### PR DESCRIPTION
There is a small issue with the added tutorial that is resolved by this PR. When loading the page it starts with both tutorial button/images being set to active and they overlap each other. This goes away once it starts moving the carousel image, but is a bit confusing at first.

<img width="1419" height="624" alt="image" src="https://github.com/user-attachments/assets/6d762f20-194e-4151-95b4-1a5fe5ec1c70" />
