### PR TITLE
Add note explaining PointClamp in SpriteBatch.Begin()

### DIFF
--- a/articles/tutorials/building_2d_games/07_optimizing_texture_rendering/index.md
+++ b/articles/tutorials/building_2d_games/07_optimizing_texture_rendering/index.md
@@ -199,6 +199,11 @@ First, we will explore creating the texture atlas and defining the texture regio
 
 [!code-csharp[](./snippets/game1/textureatlas_usage.cs?highlight=5,11-15,31-47,65-75)]
 
+> [!NOTE]
+> This example uses `SamplerState.PointClamp` in `SpriteBatch.Begin(...)`. `PointClamp` keeps scaled pixel art sharp.
+>
+> For more details, see <xref:Microsoft.Xna.Framework.Graphics.SamplerState>.
+
 The key changes in this implementation are:
 
 1. The `_logo` field was removed.


### PR DESCRIPTION
Described in #181 

Added clarifying note to the SpriteBatch.Begin(...) to explain why we are using PointClamp. Also included a link to the documentation for SamplerState.

<img width="1116" height="657" alt="Screenshot 2026-03-30 at 4 56 24 PM" src="https://github.com/user-attachments/assets/37529a44-734f-4869-a3f7-271c851fd3da" />

Closes #181 