### PR TITLE
Fix typo in Chapter 5 of Building 2D Games tutorial

### DIFF
--- a/articles/tutorials/building_2d_games/05_content_pipeline/index.md
+++ b/articles/tutorials/building_2d_games/05_content_pipeline/index.md
@@ -143,7 +143,7 @@ Now that we have a folder structure, we can add our first image asset to the pro
 Now that we have added our first asset, we can take a moment to understand what happens to this asset in the Content Pipeline workflow:
 
 1. You create source files for your game assets such as images, audio, fonts, effects, and 3D models.
-2. Using the MGCB Editor, add these assets your content project (the `Content.mgcb` file).
+2. Using the MGCB Editor, add these assets to your content project (the `Content.mgcb` file).
 3. When you perform a build of your project, the `MonoGame.Content.Builder.Task` NuGet reference will:
    1. Compile the assets defined in the content project using the **MonoGame Content Builder (MGCB)** tool into `.xnb` files.
    2. Copy the compiled `.xnb` files from the content project's build folder to your game project's build folder.


### PR DESCRIPTION
Add missing word to second bullet point of [Understanding the Content Pipeline Workflow](https://docs.monogame.net/articles/tutorials/building_2d_games/05_content_pipeline/index.html?tabs=vscode#understanding-the-content-pipeline-workflow) in Chapter 5 of [Building 2D Games](https://docs.monogame.net/articles/tutorials/building_2d_games/index.html).

<img width="994" height="247" alt="typo" src="https://github.com/user-attachments/assets/57b417bb-5c3d-44e0-a241-3f809a7be5d1" />
