### PR TITLE
Use WasKeyJustPressed for ExitOnEscape

### DIFF
--- a/articles/tutorials/building_2d_games/11_input_management/snippets/core.cs
+++ b/articles/tutorials/building_2d_games/11_input_management/snippets/core.cs
@@ -112,7 +112,7 @@ public class Core : Game
         // Update the input manager.
         Input.Update(gameTime);
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }

--- a/articles/tutorials/building_2d_games/15_audio_controller/snippets/core.cs
+++ b/articles/tutorials/building_2d_games/15_audio_controller/snippets/core.cs
@@ -132,7 +132,7 @@ public class Core : Game
         // Update the audio controller.
         Audio.Update();
 
-        if (ExitOnEscape && Input.Keyboard.IsKeyDown(Keys.Escape))
+        if (ExitOnEscape && Input.Keyboard.WasKeyJustPressed(Keys.Escape))
         {
             Exit();
         }


### PR DESCRIPTION
Use WasKeyJustPressed instead of IsKeyDown which causes issues later in the tutorial. Following the tutorial, going from 16-Working-With-Sprite-Fonts to 17-Scenes, we will reach a state that causes the title screen to be skipped on Escape press. A single Esc press exits the game completely instead of going to the title screen. This was also mentioned in #228 (bullet point 4).

There is a [demo branch](https://github.com/IvanJoskic/MonoGame.Samples/tree/bug_demo_is_key_down/Tutorials/learn-monogame-2d/src/17-Scenes) on my fork.

The [source code](https://github.com/MonoGame/MonoGame.Samples/blob/3.8.4/Tutorials/learn-monogame-2d/src/17-Scenes/MonoGameLibrary/Core.cs) for 17-Scenes from MonoGame.Samples already has this change. But the tutorial never mentions this change.

Related PR on samples: https://github.com/MonoGame/MonoGame.Samples/pull/120