### PR TITLE
Fix typo in Chapter 15 of Building 2D Games tutorial

### DIFF
--- a/articles/tutorials/building_2d_games/15_audio_controller/snippets/audiocontroller.cs
+++ b/articles/tutorials/building_2d_games/15_audio_controller/snippets/audiocontroller.cs
@@ -256,7 +256,7 @@ public class AudioController : IDisposable
     /// </summary>
     public void MuteAudio()
     {
-        // Store the volume so they can be restored during ResumeAudio
+        // Store the volume so they can be restored during UnmuteAudio
         _previousSongVolume = MediaPlayer.Volume;
         _previousSoundEffectVolume = SoundEffect.MasterVolume;
 


### PR DESCRIPTION
A comment in MuteAudio incorrectly references ResumeAudio. Should be UnmuteAudio.