### PR TITLE
Add missing snippet and bullet point to 05_transition_effect

### DIFF
--- a/articles/tutorials/advanced/2d_shaders/05_transition_effect/index.md
+++ b/articles/tutorials/advanced/2d_shaders/05_transition_effect/index.md
@@ -397,11 +397,15 @@ We will create a new class called `SceneTransition` that holds all the data for 
 
     [!code-csharp[](./snippets/snippet-5-32.cs?highlight=3)]
 
-6. Then we need to actually _set_ the `Progress` shader parameter given the current scene transition value. In the `Update()` method:
+6. Before changing scene, we need to wait for the closing transition to be done:
+
+    [!code-csharp[](./snippets/snippet-5-40.cs?highlight=7)]
+
+7. Then we need to actually _set_ the `Progress` shader parameter given the current scene transition value. In the `Update()` method:
 
     [!code-csharp[](./snippets/snippet-5-33.cs?highlight=6)]
 
-7. Finally, the scene material needs to be drawn with the right texture:
+8. Finally, the scene material needs to be drawn with the right texture:
 
 [!code-csharp[](./snippets/snippet-5-34.cs?highlight=11)]
 

--- a/articles/tutorials/advanced/2d_shaders/05_transition_effect/snippets/snippet-5-40.cs
+++ b/articles/tutorials/advanced/2d_shaders/05_transition_effect/snippets/snippet-5-40.cs
@@ -1,0 +1,13 @@
+protected override void Update(GameTime gameTime)
+{
+    // ...        
+    
+    // if there is a next scene waiting to be switch to, then transition
+    // to that scene
+    if (s_nextScene != null && SceneTransition.IsComplete)
+    {
+        TransitionScene();
+    }
+
+    // ...
+}


### PR DESCRIPTION
The documentation never tells to add that part, which results in code that doesn't work as expected and might confuse some readers. I did minimal edits, I didn't want to alter the numbering of the existing .cs snippets, so I appended a new one.