### PR TITLE
Fix an input update delay of one frame

### DIFF
--- a/articles/tutorials/building_2d_games/11_input_management/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/11_input_management/snippets/game1.cs
@@ -50,6 +50,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -61,8 +64,6 @@ public class Game1 : Core
 
         // Check for gamepad input and handle it.
         CheckGamePadInput();
-
-        base.Update(gameTime);
     }
 
     private void CheckKeyboardInput()

--- a/articles/tutorials/building_2d_games/12_collision_detection/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/12_collision_detection/snippets/game1.cs
@@ -61,6 +61,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -175,8 +178,6 @@ public class Game1 : Core
             // Assign a new random velocity to the bat
             AssignRandomBatVelocity();
         }
-
-        base.Update(gameTime);
     }
 
     private void AssignRandomBatVelocity()

--- a/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/13_working_with_tilemaps/snippets/game1.cs
@@ -84,6 +84,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+        
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -185,8 +188,6 @@ public class Game1 : Core
             // Assign a new random velocity to the bat
             AssignRandomBatVelocity();
         }
-
-        base.Update(gameTime);
     }
 
     private void AssignRandomBatVelocity()

--- a/articles/tutorials/building_2d_games/14_soundeffects_and_music/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/14_soundeffects_and_music/snippets/game1.cs
@@ -113,6 +113,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -220,8 +223,6 @@ public class Game1 : Core
             // Play the collect sound effect
             _collectSoundEffect.Play();
         }
-
-        base.Update(gameTime);
     }
 
     private void AssignRandomBatVelocity()

--- a/articles/tutorials/building_2d_games/15_audio_controller/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/15_audio_controller/snippets/game1.cs
@@ -107,6 +107,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -214,8 +217,6 @@ public class Game1 : Core
             // Play the collect sound effect.
             Audio.PlaySoundEffect(_collectSoundEffect);
         }
-
-        base.Update(gameTime);
     }
 
     private void AssignRandomBatVelocity()

--- a/articles/tutorials/building_2d_games/16_working_with_spritefonts/snippets/game1.cs
+++ b/articles/tutorials/building_2d_games/16_working_with_spritefonts/snippets/game1.cs
@@ -131,6 +131,9 @@ public class Game1 : Core
 
     protected override void Update(GameTime gameTime)
     {
+        // Update the InputManger inside base.Update() right away.
+        base.Update(gameTime);
+
         // Update the slime animated sprite.
         _slime.Update(gameTime);
 
@@ -241,8 +244,6 @@ public class Game1 : Core
             // Increase the player's score.
             _score += 100;
         }
-
-        base.Update(gameTime);
     }
 
     private void AssignRandomBatVelocity()


### PR DESCRIPTION
Previously, CheckKeyboardInput() and CheckGamePadInput() were called before the call to base.Update(), resulting in the use of stale input data. This sequence results in stale input data because the base.Update() call is where InputManager is updated with fresh input data, and because the "CheckInput" methods get their information from the InputManager. The corresponding fix simply moved the update ahead of the checker methods.