### PR TITLE
Move footer below content so it retains the same width as the content sction

### DIFF
--- a/templates/monogame/layout/_master.tmpl
+++ b/templates/monogame/layout/_master.tmpl
@@ -65,6 +65,7 @@
         {{^_disableNextArticle}}
         <div class="next-article d-print-none border-top" id="nextArticle"></div>
         {{/_disableNextArticle}}
+        {{>partials/footer}}
 
       </div>
 
@@ -77,7 +78,6 @@
     <div class="container-xxl search-results" id="search-results"></div>
     {{/_enableSearch}}
 
-      {{>partials/footer}}
       <script type="text/javascript" src="/public/injectDonateButton.js"></script>
       <script type="text/javascript" src="/public/questionAnswer.js"></script>
   </body>

--- a/templates/monogame/partials/content.tmpl.partial
+++ b/templates/monogame/partials/content.tmpl.partial
@@ -42,6 +42,7 @@
         {{^_disableNextArticle}}
             <div class="next-article d-print-none border-top" id="nextArticle"></div>
         {{/_disableNextArticle}}
+        {{>partials/footer}}
     </div>
 
     <div class="affix">
@@ -52,5 +53,4 @@
 {{#_enableSearch}}
     <div class="container-xxl search-results" id="search-results"></div>
 {{/_enableSearch}}
-{{>partials/footer}}
 </div>

--- a/templates/monogame/partials/footer.tmpl.partial
+++ b/templates/monogame/partials/footer.tmpl.partial
@@ -1,5 +1,4 @@
-<section class="container-xxl">
-    <footer class="border-top my-5 pt-5">
+    <footer class="mg-docs-footer border-top my-5 pt-5">
         <div class="row justify-content-between">
             <div class="col-6 col-lg-3 mb-3">
                 <h5>MonoGame</h5>
@@ -117,4 +116,3 @@
             </div>
         </div>
     </footer>
-</section>

--- a/templates/monogame/public/main.css
+++ b/templates/monogame/public/main.css
@@ -48,6 +48,11 @@ body[data-disable-toc="true" i] .toc-offcanvas {
   visibility: hidden;
 }
 
+body > main > .content > .mg-docs-footer,
+body[data-layout="landing"] > main > .content > .mg-docs-footer {
+  display: block;
+}
+
 th:has(a img[alt^="Figure"]),
 td:has(a img[alt^="Figure"]) {
   width: 50%;


### PR DESCRIPTION
Moves the footer partial so that it gets rendered inside the body content section below the main content so that the footer width is the same width as the page content and doesn't stretch to the width to include the table of contents and affix sections.

CSS styling applied to show it since the default `layout.scss` from docfx causes it to receive a `display: none` when moved to that section.