### PR TITLE
Fixing TOC

### DIFF
--- a/pdf/articles/toc.yml
+++ b/pdf/articles/toc.yml
@@ -56,7 +56,7 @@ items:
       - name: Debugging
         items:
           - name: Logging
-            href: ../../articles/getting_started/debugging.md
+            href: ../../articles/getting_started/logging.md
       - name: Packaging
         href: ../../articles/getting_started/packaging_games.md
       - name: Preparing for consoles


### PR DESCRIPTION
Fixes my stupidity in: #289

I did a bit of cleanup and pushed that before the merge, but I missed the TOC when I renamed the logging section.
This fixes the TOC by pointing at the correct file.